### PR TITLE
Explicitly remove classes from the Scene once done parsing

### DIFF
--- a/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
+++ b/src/main/scala/io/joern/jimple2cpg/Jimple2Cpg.scala
@@ -89,11 +89,11 @@ class Jimple2Cpg {
     new MethodDecoratorPass(cpg).createAndApply()
 
     new ContainsEdgePass(cpg).createAndApply()
-    new Linker(cpg).createAndApply()
-    new StaticCallLinker(cpg).createAndApply()
-
     new CfgDominatorPass(cpg).createAndApply()
     new CdgPass(cpg).createAndApply()
+
+    new Linker(cpg).createAndApply()
+    new StaticCallLinker(cpg).createAndApply()
 
     closeSoot()
 


### PR DESCRIPTION
Soot classes now explicitly removed from the Scene as soon as we are done using them
